### PR TITLE
Style: Add hover animation to main chat container

### DIFF
--- a/client/src/components/Chat/Chat.css
+++ b/client/src/components/Chat/Chat.css
@@ -21,6 +21,12 @@
   height: 70%; /* Increased height slightly for better aesthetics with glass */
   width: 40%;   /* Increased width slightly */
   padding: 20px; /* Added padding for content spacing */
+  transition: transform 0.3s ease, box-shadow 0.3s ease; /* Added for hover effects */
+}
+
+.container:hover {
+  transform: scale(1.02); /* Slightly enlarge on hover */
+  box-shadow: 0 12px 45px 0 rgba(0, 0, 0, 0.4); /* More pronounced shadow on hover */
 }
 
 @media (min-width: 320px) and (max-width: 480px) {

--- a/client/src/components/TextContainer/TextContainer.js
+++ b/client/src/components/TextContainer/TextContainer.js
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react'; // Consolidated React import
 
-import onlineIcon from '../../icons/onlineIcon.png';
+import onlineIcon from '../../icons/onlineIcon.png'; // Keep one onlineIcon import
 
-import React, { useState, useEffect } from 'react'; // Import useState, useEffect
-
-import onlineIcon from '../../icons/onlineIcon.png';
+// Removed duplicate React import
+// Removed duplicate onlineIcon import
 
 import './TextContainer.css';
 


### PR DESCRIPTION
- Added CSS :hover effects to the main chat window (.container).
- On hover, the container now smoothly scales up slightly (transform: scale(1.02)).
- The box-shadow also becomes more pronounced on hover for a subtle lift effect.
- Included CSS transitions for transform and box-shadow properties for smooth animation.