### PR TITLE
Fix: Correct variable usage for message status in Message.js

### DIFF
--- a/client/src/components/Messages/Message/Message.css
+++ b/client/src/components/Messages/Message/Message.css
@@ -99,4 +99,39 @@
   color: #707070;  /* Darker grey for light backgrounds */
 }
 
+.messageMeta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end; /* Aligns timestamp and ticks to the right */
+  margin-top: 5px;
+  font-size: 0.75em;
+}
+
+.messageTimestamp {
+  /* font-size: 0.75em; */ /* Moved to .messageMeta */
+  /* margin-top: 5px; */   /* Moved to .messageMeta */
+  /* text-align: right; */ /* Handled by justify-content in .messageMeta */
+  margin-right: 5px; /* Space between timestamp and tick */
+}
+
+/* Base tick style */
+.messageTick {
+  display: inline-block;
+  font-weight: bold;
+  line-height: 1; /* Ensure ticks align well with text */
+}
+
+.singleTick {
+  color: #f0f0f0; /* Same as timestampWhite for consistency on dark backgrounds */
+  /* For light backgrounds, this might need a .singleTickDark if used there */
+}
+
+.doubleTick {
+  color: #f0f0f0; /* Grey double tick for 'delivered' */
+  letter-spacing: -3px; /* Adjust spacing to make ticks closer */
+}
+
+.blueTick { /* Placeholder for later use */
+  color: #4FC3F7; /* WhatsApp blue tick color */
+  letter-spacing: -3px;
 }

--- a/client/src/components/Messages/Message/Message.js
+++ b/client/src/components/Messages/Message/Message.js
@@ -11,7 +11,8 @@ const formatTimestamp = (timestamp) => {
   return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
 };
 
-const Message = ({ message: { text, user, timestamp }, name }) => {
+// Destructure status from message prop
+const Message = ({ message: { text, user, timestamp, status }, name }) => {
   let isSentByCurrentUser = false;
   const BOT_USER_NAME = "bot"; // Define bot name, case-insensitive check later
 
@@ -44,16 +45,16 @@ const Message = ({ message: { text, user, timestamp }, name }) => {
             <p className="messageText colorWhite">{ReactEmoji.emojify(text)}</p>
             <div className="messageMeta">
               {timestamp && <p className="messageTimestamp timestampWhite">{formattedTime}</p>}
-              {message.status === 'sending' && (
+              {status === 'sending' && ( // Use destructured status
                 <span className="messageTick singleTick">&#x2713;</span> // Sending tick
               )}
-              {message.status === 'sent' && (
+              {status === 'sent' && ( // Use destructured status
                 <span className="messageTick singleTick">&#x2713;</span> // Sent tick
               )}
-              {message.status === 'delivered' && (
+              {status === 'delivered' && ( // Use destructured status
                 <span className="messageTick doubleTick">&#x2713;&#x2713;</span> // Delivered tick (grey)
               )}
-              {message.status === 'read' && (
+              {status === 'read' && ( // Use destructured status
                 <span className="messageTick blueTick">&#x2713;&#x2713;</span> // Read tick (blue)
               )}
             </div>


### PR DESCRIPTION
- Destructured the `status` property from the `message` prop directly.
- Updated the conditional rendering logic for message ticks to use the local `status` variable instead of `message.status`.
- This resolves the 'no-undef' error for `message` in the tick rendering conditions.